### PR TITLE
[BUGFIX] properly check for lazyLoadingProxy in previewImage

### DIFF
--- a/Classes/Domain/Model/Post.php
+++ b/Classes/Domain/Model/Post.php
@@ -564,12 +564,12 @@ class Post extends AbstractLocalizedEntity
      */
     public function getPreviewImage()
     {
-        if (!is_object($this->previewImage)) {
-            return;
-        }
-
         if ($this->previewImage instanceof \TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy) {
             $this->previewImage->_loadRealInstance();
+        }
+
+        if (!is_object($this->previewImage)) {
+            return;
         }
 
         return $this->previewImage->getOriginalResource();


### PR DESCRIPTION
If you add a previewImage but set it to hidden, an Exception is thrown in the Frontend:
"Call to a member function getOriginalResource() on null"
This change fixes that.
Reason: Since the previewImage is a lazyLoadingProxy, the check for is_object is always true before loading the actual instance.