### PR TITLE
[DOC] Optimizations for documentation rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor
 build
+
+# ignore generated documentation
+*GENERATED*

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -11,44 +11,42 @@
 T3Blog Extbase
 =============================================================
 
-.. only:: html
+:Classification:
+	t3extblog
 
-	:Classification:
-		t3extblog
+:Version:
+	|release|
 
-	:Version:
-		|release|
+:Language:
+	en
 
-	:Language:
-		en
+:Description:
+	This is a TYPO3 Extbase / Fluid blog extension which aims to replace t3blog.
 
-	:Description:
-		This is a TYPO3 Extbase / Fluid blog extension which aims to replace t3blog.
+:Keywords:
+	blog, blogsystem, t3blog
 
-	:Keywords:
-		blog, blogsystem, t3blog
-
-	:Copyright:
+:Copyright:
 		2018
 
-	:Author:
-		Christoph Werner, Felix Nagel
+:Author:
+	Christoph Werner, Felix Nagel
 
-	:Email:
-		info@felixnagel.com
+:Email:
+	info@felixnagel.com
 
-	:License:
-		This document is published under the Open Content License
-		available from http://www.opencontent.org/opl.shtml
+:License:
+	This document is published under the Open Content License
+	available from http://www.opencontent.org/opl.shtml
 
-	:Rendered:
-		|today|
+:Rendered:
+	|today|
 
-	The content of this document is related to TYPO3,
-	a GNU/GPL CMS/Framework available from `www.typo3.org <http://www.typo3.org/>`_.
+The content of this document is related to TYPO3,
+a GNU/GPL CMS/Framework available from `www.typo3.org <http://www.typo3.org/>`_.
 
 
-	**Table of Contents**
+**Table of Contents**
 
 .. toctree::
 	:maxdepth: 5


### PR DESCRIPTION
- remove `.. only:: html` because this has no advantage and only
prevents proper rendering on GitHub
- add pattern for generated documentation to .gitignore (if you [render locally with Docker](https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/RenderingDocs/Quickstart.html))

This is only a minor change. It will not solve all your issues right away. We did however make some changes to the [example extension manual](https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual) and some things are no longer recommended and have changed. We also plan to make a change to the documentation generated by the extension_builder. This is a work-in-progress. We are working hard to improve things and make it easier for extension authors to write good
documentation. The rest is up to you :smile:

Explanation:

* `.. only:: html`: this actually made file not get rendered well on GitHub. Also it requires extra indenting and complicates things for editors. The general way to go is to simplify and remove unnessary and possibly confusing directives.


About general problem with markup rendering on GitHub. Some of the markup used by official doc is not pure reST, it is added on by Sphinx. For some of these, there is no way to get this properly rendered on GitHub (or Gitlab for that matter), This is for example the toctree. Also the
cross-referencing via :ref: . This works great if rendered on docs.typo3.org. Not so great if rendered on GitHub. How you solve this is up to you, but we do try to establish best practices.

What you can do is one of:

1. Add a README.rst (or README.md) to your project. There, add a link to direct people to your official manual on docs.typo3.org. Actually you are already doing this. But the official docs go a step further: The README.rst is not used as documentation. It is used as a short "about this repo" page. It directs people
to the rendered documentation on docs.typo3.org, e.g. see https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-GettingStarted/blob/master/README.rst. The
project [Read the docs](https://github.com/rtfd/readthedocs.org/blob/b7e249e79c546534725a4b48ccaa015da1fbc974/README.rst) does something similar
  2. Use one single file without toctree for your documentation. You are already using README.md. You can continue using that or switch to README.rst. Either one will also get rendered on the docs server with latest version of the Docker image. Do away with the Documentation folder or just keep the images in there. Only use reStructuredText markup that can be rendered with TYPO3 docs rendering toolchain and GitHub. This is not to be recommended for large documentation projects, but for minor documentation with maybe 2 chapters, it may be better managable. But, you cannot use some of the nifty features that we offer. You are restricted to basic reStructuredText (or Markdown). It may however be the better
solution for small documentation projects. (Disclaimer: there is currently an open bug. So wait a bit or contact us on Slack #typo3-documentation before you do this)

In the past, we recommended solution 1). To be honest, I am currently a bit undecided what we should recommend in the future for extensions. So I recommend for you to wait a bit. We will be working on the [sample extension manual](https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual) some more. You can join in this process by making suggestions via [issues](https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual/issues)
or come to the Slack channel #typo3-documentation.

-- 

@sypets
TYPO3 Documentation Team member