### PR TITLE
Handle MySQL 5.7 and above for adding categories

### DIFF
--- a/Configuration/TCA/tx_t3blog_cat.php
+++ b/Configuration/TCA/tx_t3blog_cat.php
@@ -157,6 +157,7 @@ return [
                 'size' => 10,
                 'minitems' => 0,
                 'maxitems' => 1,
+                'default' => 0,
             ],
         ],
         'catname' => [


### PR DESCRIPTION
Fixes issue with MySQL Strict Mode where Categories couldn't be added with MySQL Version 5.7 and above.
See https://stackoverflow.com/a/50138799 and https://github.com/TYPO3/TYPO3.CMS/blob/b85a1a521fa5ee09de6a417f5ed713f96874e67f/typo3/sysext/frontend/Configuration/TCA/tt_content.php#L304

Fixes #196 