### PR TITLE
[BUGFIX] Handle MySQL 5.7 and above issues with default values

### DIFF
--- a/Configuration/TCA/tx_t3blog_blog_nl.php
+++ b/Configuration/TCA/tx_t3blog_blog_nl.php
@@ -69,6 +69,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'eval' => 'datetime',
                 'size' => 13,
+                'default' => 0,
             ],
         ],
         'code' => [

--- a/Configuration/TCA/tx_t3blog_cat.php
+++ b/Configuration/TCA/tx_t3blog_cat.php
@@ -157,6 +157,7 @@ return [
                 'size' => 10,
                 'minitems' => 0,
                 'maxitems' => 1,
+                'default' => 0,
             ],
         ],
         'catname' => [

--- a/Configuration/TCA/tx_t3blog_com_nl.php
+++ b/Configuration/TCA/tx_t3blog_com_nl.php
@@ -80,6 +80,7 @@ return [
                 'renderType' => 'inputDateTime',
                 'eval' => 'datetime',
                 'size' => 13,
+                'default' => 0,
             ],
         ],
         'code' => [

--- a/Configuration/TCA/tx_t3blog_post.php
+++ b/Configuration/TCA/tx_t3blog_post.php
@@ -229,6 +229,7 @@ return [
                 'foreign_selector_fieldTcaOverride' => [
                     'l10n_mode' => 'prefixLangTitle',
                 ],
+                'default' => '',
             ],
         ],
         'allow_comments' => [

--- a/Configuration/TCA/tx_t3blog_trackback.php
+++ b/Configuration/TCA/tx_t3blog_trackback.php
@@ -78,6 +78,7 @@ return [
                 'minitems' => 0,
                 'maxitems' => 1,
                 'prepend_tname' => false,
+                'default' => 0,
             ],
         ],
     ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,4 +1,13 @@
 #
+# Table structure for table 'tt_content'
+#
+CREATE TABLE tt_content (
+    irre_parentid int(11) DEFAULT '0' NOT NULL,
+    irre_parenttable varchar(20) DEFAULT '' NOT NULL
+);
+
+
+#
 # Table structure for table 'tx_t3blog_post'
 #
 CREATE TABLE tx_t3blog_post (
@@ -59,7 +68,7 @@ CREATE TABLE tx_t3blog_com_nl (
     name tinytext NOT NULL,
     post_uid int(11) DEFAULT '0' NOT NULL,
     lastsent int(11) DEFAULT '0' NOT NULL,
-    code tinytext NOT NULL,
+    code varchar(20) DEFAULT '' NOT NULL,
     privacy_policy_accepted tinyint(4) DEFAULT '0' NOT NULL
 );
 
@@ -70,7 +79,7 @@ CREATE TABLE tx_t3blog_com_nl (
 CREATE TABLE tx_t3blog_blog_nl (
     email tinytext NOT NULL,
     lastsent int(11) DEFAULT '0' NOT NULL,
-    code tinytext NOT NULL,
+    code varchar(20) DEFAULT '' NOT NULL,
     privacy_policy_accepted tinyint(4) DEFAULT '0' NOT NULL
 );
 
@@ -101,13 +110,6 @@ CREATE TABLE tx_t3blog_trackback (
     postid int(11) DEFAULT '0' NOT NULL
 );
 
-#
-# Table structure for table 'tt_content'
-#
-CREATE TABLE tt_content (
-    irre_parentid int(11) DEFAULT '0' NOT NULL,
-    irre_parenttable tinytext NOT NULL
-);
 
 #
 # Table structure for table 'tx_t3blog_post_cat_mm'

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -68,7 +68,7 @@ CREATE TABLE tx_t3blog_com_nl (
     name tinytext NOT NULL,
     post_uid int(11) DEFAULT '0' NOT NULL,
     lastsent int(11) DEFAULT '0' NOT NULL,
-    code varchar(20) DEFAULT '' NOT NULL,
+    code varchar(32) DEFAULT '' NOT NULL,
     privacy_policy_accepted tinyint(4) DEFAULT '0' NOT NULL
 );
 
@@ -79,7 +79,7 @@ CREATE TABLE tx_t3blog_com_nl (
 CREATE TABLE tx_t3blog_blog_nl (
     email tinytext NOT NULL,
     lastsent int(11) DEFAULT '0' NOT NULL,
-    code varchar(20) DEFAULT '' NOT NULL,
+    code varchar(32) DEFAULT '' NOT NULL,
     privacy_policy_accepted tinyint(4) DEFAULT '0' NOT NULL
 );
 


### PR DESCRIPTION
I added some default values for the columns.
I also reordered ext_tables.sql so the additions for the TYPO3 tables are at the top and then all the custom tables.