### PR TITLE
bugfix in CreateMissingCategorySlugs: third param of createMissingSlugs() must be a int. string given.

### DIFF
--- a/Classes/UpgradeWizard/CreateMissingCategorySlugs.php
+++ b/Classes/UpgradeWizard/CreateMissingCategorySlugs.php
@@ -23,7 +23,7 @@ class CreateMissingCategorySlugs extends AbstractSlugUpgradeWizard
 
     public function executeUpdate(): bool
     {
-        $count = $this->createMissingSlugs('tx_t3blog_cat', 'url_segment', 'category records');
+        $count = $this->createMissingSlugs('tx_t3blog_cat', 'url_segment', 100);
         $this->output->writeln($count.' missing category record slugs have been updated.');
 
         return true;


### PR DESCRIPTION
bugfix in CreateMissingCategorySlugs: AbstractSlugUpgradeWizard->createMissingSlugs() third param must be a int (param limit). String given.