### PR TITLE
AbstractSlugUpgradeWizard: Querybuidler->where(): one string predicate by parameter instead of an array of string in a single parameter.

### DIFF
--- a/Classes/UpgradeWizard/AbstractSlugUpgradeWizard.php
+++ b/Classes/UpgradeWizard/AbstractSlugUpgradeWizard.php
@@ -54,7 +54,7 @@ abstract class AbstractSlugUpgradeWizard extends AbstractUpgradeWizard implement
 
         foreach ($rows as $row) {
             $queryBuilder
-                ->update($table)->where([$constraint, $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT))])
+                ->update($table)->where($constraint, $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT)))
                 ->set($slug, $slugService->generate($row, $row['pid']))
                 ->execute();
         }


### PR DESCRIPTION
bugfix in AbstractSlugUpgradeWizard.php : Querybuidler->where(): one string predicate by parameter instead of an array of string in a single parameter.