### PR TITLE
[BUGFIX] Fix access to array key with array

### DIFF
--- a/Classes/ViewHelpers/Backend/LocalizationViewHelper.php
+++ b/Classes/ViewHelpers/Backend/LocalizationViewHelper.php
@@ -81,7 +81,7 @@ class LocalizationViewHelper extends AbstractBackendViewHelper
         $translations = self::getTranslateTools()->translationInfo($table, $row['uid'], 0, $row);
 
         if (is_array($translations) && is_array($translations['translations'])) {
-            foreach ($translations['translations'] as $sysLanguageUid) {
+            foreach ($translations['translations'] as $sysLanguageUid => $_) {
                 if (!$GLOBALS['BE_USER']->checkLanguageAccess($sysLanguageUid)) {
                     continue;
                 }

--- a/Classes/ViewHelpers/Backend/LocalizationViewHelper.php
+++ b/Classes/ViewHelpers/Backend/LocalizationViewHelper.php
@@ -74,6 +74,8 @@ class LocalizationViewHelper extends AbstractBackendViewHelper
      *
      * @param string $table The table
      * @param array  $row   The record for which to make the localization panel.
+     *
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
     public static function getLocalizedRecords(string $table, array $row): array
     {


### PR DESCRIPTION
Within the foreach loop, $sysLanguageUid is not only the language uid, but an array, where the language uid is the key of the array. This fix separates the array from the key, so that $sysLanguageUid is only the key (and therefore the integer language uid).

Resolves: #279