### PR TITLE
[BUGFIX] Fix missing backend module

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -12,7 +12,7 @@ return [
     'web_T3extblogBlogsystem' => [
         'parent' => 'web',
         'position' => ['after' => 'web_info'],
-        'access' => 'user,group',
+        'access' => 'user',
         'workspaces' => '*',
         'iconIdentifier' => 'extensions-t3extblog-plugin',
         'labels' => 'LLL:EXT:t3extblog/Resources/Private/Language/locallang_mod.xlf',


### PR DESCRIPTION
The backend module configuration property "access" does no longer allow the value "group" (see
https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.html#confval-backend-module-access) If provided, the backend module is hidden from user access administration.

Resolves: #278