### PR TITLE
[BUGFIX] Fix comment and post subscription delete

### DIFF
--- a/Classes/Controller/AbstractSubscriberController.php
+++ b/Classes/Controller/AbstractSubscriberController.php
@@ -83,7 +83,7 @@ abstract class AbstractSubscriberController extends AbstractController
 
     abstract protected function dispatchConfirmEvent(AbstractSubscriber $subscriber): AbstractSubscriber;
 
-    public function deleteAction(AbstractSubscriber $subscriber = null): ResponseInterface
+    protected function delete(AbstractSubscriber $subscriber = null): ResponseInterface
     {
         if (($authResult = $this->checkAuth()) instanceof ResponseInterface) {
             return $authResult;

--- a/Classes/Controller/BlogSubscriberController.php
+++ b/Classes/Controller/BlogSubscriberController.php
@@ -99,15 +99,10 @@ class BlogSubscriberController extends AbstractSubscriberController
         return $event->getSubscriber();
     }
 
-    /**
-     * Do not remove @param (needed for Extbase)
-     *
-     * @param BlogSubscriber $subscriber
-     */
     #[IgnoreValidation(['value' => 'subscriber'])]
-    public function deleteAction($subscriber = null): ResponseInterface
+    public function deleteAction(BlogSubscriber $subscriber = null): ResponseInterface
     {
-        return parent::deleteAction($subscriber);
+        return $this->delete($subscriber);
     }
 
     protected function dispatchDeleteEvent(AbstractSubscriber $subscriber): AbstractSubscriber

--- a/Classes/Controller/PostSubscriberController.php
+++ b/Classes/Controller/PostSubscriberController.php
@@ -54,17 +54,10 @@ class PostSubscriberController extends AbstractSubscriberController
         return $event->getSubscriber();
     }
 
-    /**
-     * Do not remove @param (needed for Extbase)
-     *
-     * @param PostSubscriber $subscriber
-     */
     #[IgnoreValidation(['value' => 'subscriber'])]
-    public function deleteAction($subscriber = null): ResponseInterface
+    public function deleteAction(PostSubscriber $subscriber = null): ResponseInterface
     {
-        parent::deleteAction($subscriber);
-
-        return $this->htmlResponse();
+        return $this->delete($subscriber);
     }
 
     protected function dispatchDeleteEvent(AbstractSubscriber $subscriber): AbstractSubscriber

--- a/Classes/Domain/Model/PostSubscriber.php
+++ b/Classes/Domain/Model/PostSubscriber.php
@@ -28,7 +28,7 @@ class PostSubscriber extends AbstractSubscriber
     protected ?Post $post = null;
 
     /**
-     * @var ObjectStorage<Comment>
+     * @var ?ObjectStorage<Comment>
      */
     #[Lazy]
     protected ?ObjectStorage $postComments = null;

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -174,9 +174,6 @@ return [
             'email' => [
                 'fieldName' => 'email'
             ],
-            'postUid' => [
-                'fieldName' => 'post_uid'
-            ],
             'lastSent' => [
                 'fieldName' => 'lastsent'
             ],


### PR DESCRIPTION
Object argument mapping will no longer work using doc header. Remove needless property mapping and faulty var doc header.

See #286